### PR TITLE
plant and machine line state cleared on edit

### DIFF
--- a/src/pages/mastery/MachineLine.tsx
+++ b/src/pages/mastery/MachineLine.tsx
@@ -193,9 +193,7 @@ const MachineLine = () => {
         body,
       );
       if (res.statusCode === 200) {
-        setNewMachineLine(initialState);
-        setFileName('');
-        setImageURl('');
+        handleClear();
         setShowEditMachineLineModal(false);
         setShowEditSuccessModal(true);
         fetchAllMachineLine(paginationData?.current_page);
@@ -225,9 +223,7 @@ const MachineLine = () => {
 
     const res = await MACHINE_LINE_SERVICES.addMachineLine(body);
     if (res.statusCode === 201) {
-      setNewMachineLine(initialState);
-      setFileName('');
-      setImageURl('');
+      handleClear();
       toast.success('Machine Line added successfully');
       fetchAllMachineLine(1);
     }
@@ -274,6 +270,7 @@ const MachineLine = () => {
             className="absolute right-[10px] top-[10px] cursor-pointer"
             onClick={() => {
               setShowEditMachineLineModal(false);
+              handleClear();
             }}
           >
             <ChevronCancelIcon />
@@ -373,7 +370,7 @@ const MachineLine = () => {
           onChange={handleChange}
           type="text"
           name="machineLineName"
-          value={newMachineLine.machineLineName}
+          value={showEditMachineLineModal ? '' : newMachineLine?.machineLineName}
           mandatory={true}
         />
         <Input
@@ -382,7 +379,7 @@ const MachineLine = () => {
           name="description"
           type="text"
           onChange={handleChange}
-          value={newMachineLine.description}
+          value={showEditMachineLineModal ? '' : newMachineLine?.description}
           mandatory={true}
         />
         <Dropdown
@@ -403,8 +400,8 @@ const MachineLine = () => {
         fileFormat=".jpg, .png"
         handleFile={handleFile}
         uploadStatus={upload}
-        fileName={fileName}
-        image={imageURL}
+        fileName={showEditMachineLineModal ? '' : fileName}
+        image={showEditMachineLineModal ? '' : imageURL}
       />
       <div className="flex gap-4 mt-8 mb-8">
         <Button

--- a/src/pages/mastery/Plant.tsx
+++ b/src/pages/mastery/Plant.tsx
@@ -114,6 +114,13 @@ function Plant() {
     return newPlant.plantName && newPlant.description && newPlant.image ? false : true;
   };
 
+  // Clear button functionalities
+  const handleClear = () => {
+    setNewPlant(initialState);
+    setFileName('');
+    setImageURl('');
+  };
+
   const columns = [
     {
       title: 'Plant Name',
@@ -180,9 +187,7 @@ function Plant() {
     };
     const res = await PLANT_SERVICES.addPlant(body);
     if (res?.statusCode === 201) {
-      setNewPlant(initialState);
-      setFileName('');
-      setImageURl('');
+      handleClear();
       toast.success('Plant added successfully');
       fetchPlantDataByOrgId(1);
     }
@@ -198,14 +203,13 @@ function Plant() {
     const res = await PLANT_SERVICES.updatePlantbyId(orgID, newPlant.plantId, body);
     if (res.statusCode === 200) {
       fetchPlantDataByOrgId(paginationData?.current_page);
-      setNewPlant(initialState);
+      handleClear();
       setEditPlant(false);
       setShowEditSuccessModal(true);
     }
   };
 
   const onCloseEditModal = () => {
-    setNewPlant(initialState);
     setShowEditSuccessModal(false);
   };
 
@@ -218,7 +222,7 @@ function Plant() {
             className="w-[270px] border-[1px] h-[46px] px-3 rounded-[50px] border-[#A9A9A9] p-[16px] text-[14px]"
             placeholder="Plant Name*"
             type="text"
-            value={newPlant.plantName}
+            value={editPlant ? '' : newPlant?.plantName}
             name="plantName"
             onChange={handleChange}
           />
@@ -227,7 +231,7 @@ function Plant() {
             placeholder="Plant Description"
             type="text"
             name="description"
-            value={newPlant.description}
+            value={editPlant ? '' : newPlant?.description}
             onChange={handleChange}
           />
         </div>
@@ -238,17 +242,13 @@ function Plant() {
             fileFormat=".jpg, .png"
             handleFile={handleFile}
             uploadStatus={uploadStatus}
-            image={imageURL}
-            fileName={fileName}
+            fileName={editPlant ? '' : fileName}
+            image={editPlant ? '' : imageURL}
           />
         </div>
         <div className="flex justify-start flex-row w-full gap-4 mt-8 mb-8">
           <Button
-            onClick={() => {
-              setNewPlant(initialState);
-              setFileName('');
-              setImageURl('');
-            }}
+            onClick={handleClear}
             className="py-3 px-6 rounded-2xl tracking-[0.32px] text-base leading-4 font-medium"
             label="Clear"
             variant="secondary"
@@ -328,6 +328,7 @@ function Plant() {
             className="absolute right-[10px] top-[10px] cursor-pointer"
             onClick={() => {
               setEditPlant(false);
+              handleClear();
             }}
           >
             <ChevronCancelIcon />
@@ -362,6 +363,7 @@ function Plant() {
                 name="description"
                 placeholder="Enter Plant Description"
                 value={newPlant?.description}
+                // value={showEditModal ? '' : newShop.description}
                 onChange={handleChange}
               />
               <FileUploader

--- a/src/pages/mastery/Plant.tsx
+++ b/src/pages/mastery/Plant.tsx
@@ -363,7 +363,6 @@ function Plant() {
                 name="description"
                 placeholder="Enter Plant Description"
                 value={newPlant?.description}
-                // value={showEditModal ? '' : newShop.description}
                 onChange={handleChange}
               />
               <FileUploader


### PR DESCRIPTION
**Title**: Mastery - Plant and Machine line state clearance

**Description**: There was an issue in Mastery - Plant and Machine Line tabs, When we open edit modal, the selected data gets filled in the input fields, dropdown and the file uploader, that we use in creating a new plant/machine line, When we close the modal by clicking on the exit button or the submit button, the data remains in those fields. It should not be like that. 

**Screenshot of the issue:**
![MicrosoftTeams-image (41)](https://github.com/OCBM/OCBM-FE/assets/131864208/3a472c21-1388-4f39-8967-4fdd85640aa2)
![MicrosoftTeams-image (42)](https://github.com/OCBM/OCBM-FE/assets/131864208/f3a97fc8-7889-4a15-9178-70854be91d52)

**Tasks done:**
1. Mastery - Plant state issue fixed
2. Mastery - Machine line state issue fixed

**Screenshots after fixing the issue:**  
![image](https://github.com/OCBM/OCBM-FE/assets/131864208/562a738b-92ce-434f-93f2-55a18cd352bd)
![image](https://github.com/OCBM/OCBM-FE/assets/131864208/0612a817-a9c3-4bf7-b325-48763519ea69)

Reviewers : @chandran-kannan 